### PR TITLE
fix handling of TXT records

### DIFF
--- a/sender_policy_flattener/crawler.py
+++ b/sender_policy_flattener/crawler.py
@@ -30,17 +30,17 @@ def crawl(rrname, rrtype, domain, ns=default_resolvers):
     except Exception as err:
         print(repr(err), rrname, rrtype)
     else:
-        answer = "".join([str(a) for a in answers])
-        for pair in tokenize(answer):
-            rname, rtype = pair
-            if rtype is None:
-                continue
-            if rtype == "txt":
-                for ip in crawl(rname, "txt", domain, ns):
-                    yield ip
-                continue
-            try:
-                for ip in handler_mapping[rtype](rname, domain, ns):
-                    yield ip
-            except (NXDOMAIN, NoAnswer) as e:
-                print(e)
+        for answer in answers:
+            for pair in tokenize(str(answer), rrtype):
+                rname, rtype = pair
+                if rtype is None:
+                    continue
+                if rtype == "txt":
+                    for ip in crawl(rname, rtype, domain, ns):
+                        yield ip
+                    continue
+                try:
+                    for ip in handler_mapping[rtype](rname, domain, ns):
+                        yield ip
+                except (NXDOMAIN, NoAnswer) as e:
+                    print(e)

--- a/sender_policy_flattener/crawler.py
+++ b/sender_policy_flattener/crawler.py
@@ -30,7 +30,7 @@ def crawl(rrname, rrtype, domain, ns=default_resolvers):
     except Exception as err:
         print(repr(err), rrname, rrtype)
     else:
-        answer = " ".join([str(a) for a in answers])
+        answer = "".join([str(a) for a in answers])
         for pair in tokenize(answer):
             rname, rtype = pair
             if rtype is None:


### PR DESCRIPTION
Currently the crawler joins overlong records with a space.

This breaks SPF record entries that have been split within an entry (e.g. `0.spf0.hubspotemail.net`):

```
"v=spf1 ip4:3.93.157.0/24 ip4:3.210.190.0/24 ip4:18.208.124.128/25 ip4:54.174.52.0/24 ip4:54.174.57.0/24 ip4:54.174.59.0/24 ip4:54.174.60.0/23 ip4:54.174.63.0/24 ip4:139.180.17.0/24 ip4:141.193.184.32/27 ip4:141.193.184.64/26 ip4:141.193.184.128/25 ip4:1" "41.193.185.32/27 ip4:141.193.185.64/26 ip4:141.193.185.128/25 ip4:143.244.80.0/20 ip4:158.247.16.0/20 -all"
```

This leads to broken SPF entries in the flattened result.

I reworked the response handling and tokenization instead now. By handling each DNS RR individually during tokenization and giving the tokenizer more context, it's possible to solve this without affecting the handling of other RR types.